### PR TITLE
Fix tlwg build with autoconf-archive and py3-fontforge

### DIFF
--- a/font-tlwg.yaml
+++ b/font-tlwg.yaml
@@ -1,0 +1,53 @@
+package:
+  name: font-tlwg
+  version: 0.7.3
+  epoch: 0
+  description: font-tlwg
+  copyright:
+    - license: GPL
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - fontforge
+      - libtool
+      - m4
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tlwg/fonts-tlwg
+      expected-commit: a2d3f66b3004276232eb279c3392758c05bcc279
+      tag: v${{package.version}}
+
+  - runs: ./autogen.sh
+
+  - runs: |
+      ./configure \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --enable-ttf \
+        --disable-otf \
+        --with-ttfdir=/usr/share/fonts/TTF
+
+      make
+
+      mkdir -p "${{targets.destdir}}"/usr/share/fontconfig
+      mkdir -p "${{targets.destdir}}"/usr/share/licenses/${{package.name}}
+      make DESTDIR="${{targets.destdir}}" install
+      mkdir -p "${{targets.destdir}}"/etc/fonts
+      mv "${{targets.destdir}}"/usr/share/fontconfig/conf.avail "${{targets.destdir}}"/etc/fonts
+      rm -r "${{targets.destdir}}"/usr/share/fontconfig
+      install -Dm644 COPYING "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/COPYING
+
+update:
+  enabled: true
+  github:
+    identifier: tlwg/fonts-tlwg
+    strip-prefix: v

--- a/font-tlwg.yaml
+++ b/font-tlwg.yaml
@@ -10,6 +10,7 @@ environment:
   contents:
     packages:
       - autoconf
+      - autoconf-archive
       - automake
       - build-base
       - busybox
@@ -18,6 +19,7 @@ environment:
       - libtool
       - m4
       - pkgconf-dev
+      - py3-fontforge
 
 pipeline:
   - uses: git-checkout

--- a/ttf-arphic-ukai.yaml
+++ b/ttf-arphic-ukai.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: CJK Unicode font Kaiti style
   copyright:
-    - license: Arphic-1999
+    - license: Arphic Public License
 
 environment:
   contents:

--- a/ttf-arphic-uming.yaml
+++ b/ttf-arphic-uming.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: CJK Unicode font Ming style
   copyright:
-    - license: Arphic-1999
+    - license: Arphic Public License
 
 environment:
   contents:


### PR DESCRIPTION
Fix tlwg build by adding autoconf-archive and py3-fontforge in build dependencies